### PR TITLE
Added option config.verbose to not print output in console

### DIFF
--- a/src/kss_jade_react_generator.js
+++ b/src/kss_jade_react_generator.js
@@ -77,20 +77,27 @@ kssJadeReactGenerator.init = function(config) {
   this.routerContext = {};
   this.helpers = {};
 
-  console.log('');
-  console.log('kssJadeReactGenerator');
-  console.log('Generating your KSS style guide!');
-  console.log('');
-  console.log(' * KSS Source    : ' + this.config.source.join(', '));
-  console.log(' * Destination   : ' + this.config.destination);
-  console.log(' * Template      : ' + this.config.template);
-  if (this.config.helpers) {
+  if (this.config.verbose) {
+    console.log('');
+    console.log('kssJadeReactGenerator');
+    console.log('Generating your KSS style guide!');
+    console.log('');
+    console.log(' * KSS Source    : ' + this.config.source.join(', '));
+    console.log(' * Destination   : ' + this.config.destination);
+    console.log(' * Template      : ' + this.config.template);
+  }
+
+  if (this.config.helpers && this.config.verbose) {
     console.log(' * Helpers       : ' + this.config.helpers.join(', '));
   }
-  if (this.config.routerHelpers) {
+
+  if (this.config.routerHelpers && this.config.verbose) {
     console.log(' * RouterHelpers : ' + this.config.routerHelpers.join(', '));
   }
-  console.log('');
+
+  if (this.config.verbose) {
+    console.log('');
+  }
 
   // Create a new destination directory.
   try {
@@ -187,16 +194,20 @@ kssJadeReactGenerator.generate = function(styleguide) {
   var key;
   var bundler;
 
-  console.log(styleguide.data.files.map(function(file) {
-    return ' - ' + file;
-  }).join('\n'));
+  if (this.config.verbose) {
+    console.log(styleguide.data.files.map(function(file) {
+      return ' - ' + file;
+    }).join('\n'));
+  }
 
   // Throw an error if no KSS sections are found in the source files.
   if (sectionCount === 0) {
     throw new Error('No KSS documentation discovered in source files.');
   }
 
-  console.log('...Determining section markup:');
+  if (this.config.verbose) {
+    console.log('...Determining section markup:');
+  }
 
   for (i = 0; i < sectionCount; i += 1) {
     // Register all the markup blocks as Jade partials.
@@ -223,7 +234,11 @@ kssJadeReactGenerator.generate = function(styleguide) {
         if (!files.length) {
           partial.markup += ' NOT FOUND!';
         }
-        console.log(' - ' + partial.reference + ': ' + partial.markup);
+
+        if (this.config.verbose) {
+          console.log(' - ' + partial.reference + ': ' + partial.markup);
+        }
+
         if (files.length) {
           // Load the partial's markup from file.
           partial.file = files[0];
@@ -243,7 +258,9 @@ kssJadeReactGenerator.generate = function(styleguide) {
           }
         }
       } else {
-        console.log(' - ' + partial.reference + ': inline markup');
+        if (this.config.verbose) {
+          console.log(' - ' + partial.reference + ': inline markup');
+        }
       }
       // Save the name of the partial and its data for retrieval in the markup
       // helper, where we only know the reference.
@@ -258,7 +275,9 @@ kssJadeReactGenerator.generate = function(styleguide) {
     }
   }
 
-  console.log('...Generating style guide sections:');
+  if (this.config.verbose) {
+    console.log('...Generating style guide sections:');
+  }
 
   // Now, group all of the sections by their root
   // reference, and make a page for each.
@@ -296,7 +315,11 @@ kssJadeReactGenerator.generatePage = function(styleguide, sections, root, sectio
 
   if (root === 'styleguide.homepage') {
     filename = 'index.html';
-    console.log(' - homepage');
+
+    if (this.config.verbose) {
+      console.log(' - homepage');
+    }
+
     // Ensure homepageText is a non-false value.
     for (key in this.config.source) {
       if (!homepageText) {
@@ -312,15 +335,21 @@ kssJadeReactGenerator.generatePage = function(styleguide, sections, root, sectio
     }
     if (!homepageText) {
       homepageText = ' ';
-      console.log('   ...no homepage content found in ' + this.config.homepage + '.');
+
+      if (this.config.verbose) {
+        console.log('   ...no homepage content found in ' + this.config.homepage + '.');
+      }
     }
   } else {
     filename = 'section-' + KssSection.prototype.encodeReferenceURI(root) + '.html';
-    console.log(
-      ' - section ' + root + ' [',
-      styleguide.section(root) ? styleguide.section(root).header() : 'Unnamed',
-      ']'
-    );
+
+    if (this.config.verbose) {
+      console.log(
+        ' - section ' + root + ' [',
+        styleguide.section(root) ? styleguide.section(root).header() : 'Unnamed',
+        ']'
+      );
+    }
   }
   // Create the HTML to load the optional CSS and JS.
   /*eslint-disable guard-for-in*/


### PR DESCRIPTION
## WHAT?

Use [kss-node](https://github.com/kss-node/kss-node) `verbose` option to avoid all this output:

```
kssJadeReactGenerator
Generating your KSS style guide!

 * KSS Source    : /Users/username/code/app/stylesheets, /Users/username/code/styleguide
 * Destination   : /Users/username/code/styleguide/build
 * Template      : /Users/username/code/styleguide/template
 * Helpers       : /Users/username/code/styleguide/helpers
 * RouterHelpers : 

 49% 959/1475 build modules -/Users/username/code/app/stylesheets/app/layout/_app-header.scss
 - /Users/username/code/app/stylesheets/app/layout/_box_module.scss
 - /Users/username/code/app/stylesheets/app/layout/_grid.scss
 - /Users/username/code/app/stylesheets/app/layout/_layout.scss
 - /Users/username/code/ftb/app/stylesheets/app/layout/_loading.scss
 - /Users/username/code/ftb/app/stylesheets/app/layout/_new-layout.scss
 - /Users/username/code/app/stylesheets/app/layout/_panes.scss
 - ...This can be very long....
...Determining section markup:
 - Buttons - Base style: jade/buttons/base.jade
 49% 960/1475 build modules...Generating style guide sections:
 - section Buttons [ Buttons ]
 48% 961/1499 build modules - section Colors [ Colors ]
 - homepage
... This can be also very long...
```
